### PR TITLE
Add extra variables for coins, and stars. fix performance issue with interaction handler

### DIFF
--- a/ResoniteMario64/Constants.cs
+++ b/ResoniteMario64/Constants.cs
@@ -29,6 +29,7 @@ public static class Constants
     public const string HealthPointsVarName = "HealthPoints";
     public const string CoinsVarName = "Coins";
     public const string RedCoinVarName = "RedCoins";
+    public const string StarVarName = "Stars";
     public const string ActionFlagsVarName = "ActionFlags";
     public const string StateFlagsVarName = "StateFlags";
 

--- a/ResoniteMario64/Constants.cs
+++ b/ResoniteMario64/Constants.cs
@@ -27,6 +27,8 @@ public static class Constants
     public const string CrouchVarName = "Crouch";
     public const string IsShownVarName = "IsShown";
     public const string HealthPointsVarName = "HealthPoints";
+    public const string CoinsVarName = "Coins";
+    public const string RedCoinVarName = "RedCoins";
     public const string ActionFlagsVarName = "ActionFlags";
     public const string StateFlagsVarName = "StateFlags";
 

--- a/ResoniteMario64/Mario64/Components/Context/SM64 Context Audio.cs
+++ b/ResoniteMario64/Mario64/Components/Context/SM64 Context Audio.cs
@@ -110,6 +110,7 @@ public sealed partial class SM64Context
                     if (overrideForUser != null)
                     {
                         overrideForUser.Default.Value = defaultVolume;
+                        overrideForUser.CreateOverrideOnWrite.Value = true;
                     }
                 });
 

--- a/ResoniteMario64/Mario64/Components/Context/SM64 Context Inputs.cs
+++ b/ResoniteMario64/Mario64/Components/Context/SM64 Context Inputs.cs
@@ -194,8 +194,10 @@ public sealed partial class SM64Context
     [HarmonyPatch(typeof(InteractionHandler), nameof(InteractionHandler.BeforeInputUpdate))]
     public class MarioInputBlocker
     {
+        private static bool _blockedInputs;
         public static void Postfix(InteractionHandler __instance)
         {
+            
             if (__instance.Slot.ActiveUser != __instance.LocalUser) return;
             
             bool isIndex = __instance.Controller is IndexController;
@@ -226,8 +228,10 @@ public sealed partial class SM64Context
                 {
                     __instance.Inputs.Axis.RegisterBlocks = true;
                 }
+
+                _blockedInputs = true;
             }
-            else
+            else if (_blockedInputs)
             {
                 if (isIndex)
                 {
@@ -262,6 +266,8 @@ public sealed partial class SM64Context
                 {
                     __instance.Inputs.Axis.RegisterBlocks = true;
                 }
+
+                _blockedInputs = false;
             }
             /*if (ShouldBlockInputs(__instance, __instance.LocalUser.Primaryhand))
             {

--- a/ResoniteMario64/Mario64/Components/SM64 Mario.cs
+++ b/ResoniteMario64/Mario64/Components/SM64 Mario.cs
@@ -291,6 +291,18 @@ public sealed class SM64Mario : ISM64Object
         set => MarioSpace.TryWriteValue(StateFlagsVarName, value);
     }
 
+    public int SyncedCoinCounter
+    {
+        get => MarioSpace.TryReadValue(CoinsVarName, out int coinCounter) ? coinCounter : 0;
+        set => MarioSpace.TryWriteValue(CoinsVarName, value);
+    }
+
+    public int SyncedRedCoinCounter
+    {
+        get => MarioSpace.TryReadValue(RedCoinVarName, out int redCoinCounter) ? redCoinCounter : 0;
+        set => MarioSpace.TryWriteValue(RedCoinVarName, value);
+    }
+
     public uint CurrentActionFlags => CurrentState.ActionFlags;
     public uint CurrentStateFlags => CurrentState.StateFlags;
     private uint _lastActionFlags;
@@ -401,6 +413,12 @@ public sealed class SM64Mario : ISM64Object
 
             DynamicValueVariable<uint> stateFlags = varsSlot.AttachComponent<DynamicValueVariable<uint>>();
             stateFlags.VariableName.Value = StateFlagsVarName;
+
+            DynamicValueVariable<int> coinCounter = varsSlot.AttachComponent<DynamicValueVariable<int>>();
+            coinCounter.VariableName.Value = CoinsVarName;
+
+            DynamicValueVariable<int> redCoinCounter = varsSlot.AttachComponent<DynamicValueVariable<int>>();
+            redCoinCounter.VariableName.Value = RedCoinVarName;
 
             slot.RunInUpdates(1, () => slot.SetParent(instance.MyMariosSlot));
         }
@@ -1024,26 +1042,23 @@ public sealed class SM64Mario : ISM64Object
         {
             case SM64InteractableType.GoldCoin:
                 Interop.PlaySoundGlobal(Sounds.SOUND_GENERAL_COIN);
+                SyncedCoinCounter++;
                 Heal(1);
                 break;
             case SM64InteractableType.BlueCoin:
                 Interop.PlaySoundGlobal(Sounds.SOUND_GENERAL_COIN);
+                SyncedCoinCounter += 5;
                 Heal(5);
                 break;
             case SM64InteractableType.RedCoin:
-                Sounds redCoinSound = typeId switch
-                {
-                    0 => Sounds.Menu_CollectRedCoin0,
-                    1 => Sounds.Menu_CollectRedCoin1,
-                    2 => Sounds.Menu_CollectRedCoin2,
-                    3 => Sounds.Menu_CollectRedCoin3,
-                    4 => Sounds.Menu_CollectRedCoin4,
-                    5 => Sounds.Menu_CollectRedCoin5,
-                    6 => Sounds.Menu_CollectRedCoin6,
-                    7 => Sounds.Menu_CollectRedCoin7,
-                    _ => Sounds.SOUND_GENERAL_RED_COIN
-                };
-                Interop.PlaySoundGlobal(redCoinSound);
+                int currentRedIndex = SyncedRedCoinCounter;
+
+                Sounds redSound = GetRedCoinSound(typeId == -1 ? currentRedIndex : typeId);
+
+                Interop.PlaySoundGlobal(redSound);
+
+                SyncedRedCoinCounter = currentRedIndex == 7 ? 0 : currentRedIndex + 1;
+                SyncedCoinCounter += 2;
                 Heal(2);
                 break;
             case SM64InteractableType.VanishCap:
@@ -1087,6 +1102,28 @@ public sealed class SM64Mario : ISM64Object
         }
 
         interactableCollider.Slot.ActiveSelf = !disable;
+    }
+
+    private static Sounds GetRedCoinSound(int redIndex)
+    {
+        if (redIndex < 0 || redIndex > 7)
+        {
+            return Sounds.SOUND_GENERAL_RED_COIN;
+        }
+
+        Sounds[] sounds = new Sounds[]
+        {
+            Sounds.Menu_CollectRedCoin0,
+            Sounds.Menu_CollectRedCoin1,
+            Sounds.Menu_CollectRedCoin2,
+            Sounds.Menu_CollectRedCoin3,
+            Sounds.Menu_CollectRedCoin4,
+            Sounds.Menu_CollectRedCoin5,
+            Sounds.Menu_CollectRedCoin6,
+            Sounds.Menu_CollectRedCoin7
+        };
+
+        return sounds[redIndex];
     }
 
     public void SetMarioAsNuked(bool delete = false)

--- a/ResoniteMario64/Mario64/Components/SM64 Mario.cs
+++ b/ResoniteMario64/Mario64/Components/SM64 Mario.cs
@@ -291,6 +291,12 @@ public sealed class SM64Mario : ISM64Object
         set => MarioSpace.TryWriteValue(StateFlagsVarName, value);
     }
 
+    public int SyncedStarCounter
+    {
+        get => MarioSpace.TryReadValue(StarVarName, out int starCounter) ? starCounter : 0;
+        set => MarioSpace.TryWriteValue(StarVarName, value);
+    }
+
     public int SyncedCoinCounter
     {
         get => MarioSpace.TryReadValue(CoinsVarName, out int coinCounter) ? coinCounter : 0;
@@ -305,8 +311,8 @@ public sealed class SM64Mario : ISM64Object
 
     public uint CurrentActionFlags => CurrentState.ActionFlags;
     public uint CurrentStateFlags => CurrentState.StateFlags;
-    private uint _lastActionFlags;
 
+    private uint _lastActionFlags;
     // private uint _lastStateFlags;
 
 #endregion
@@ -419,6 +425,9 @@ public sealed class SM64Mario : ISM64Object
 
             DynamicValueVariable<int> redCoinCounter = varsSlot.AttachComponent<DynamicValueVariable<int>>();
             redCoinCounter.VariableName.Value = RedCoinVarName;
+            
+            DynamicValueVariable<int> starCounter = varsSlot.AttachComponent<DynamicValueVariable<int>>();
+            starCounter.VariableName.Value = StarVarName;
 
             slot.RunInUpdates(1, () => slot.SetParent(instance.MyMariosSlot));
         }
@@ -1075,6 +1084,7 @@ public sealed class SM64Mario : ISM64Object
                 break;
             case SM64InteractableType.Star:
                 Interop.PlaySoundGlobal(Sounds.Menu_StarSound);
+                SyncedStarCounter++;
                 Heal(8);
                 SetForwardVelocity(0f);
                 SetAction(ActionFlag.Freefall);

--- a/ResoniteMario64/Mario64/Patches.cs
+++ b/ResoniteMario64/Mario64/Patches.cs
@@ -29,10 +29,10 @@ public class Patches
     {
         public static void Prefix(UpdateManager __instance)
         {
-            if (SM64Context.Instance?.World == __instance.World)
-            {
-                SM64Context.Instance?.OnCommonUpdate();
-            }
+            SM64Context instance = SM64Context.Instance;
+            if (instance == null || instance.World != __instance.World) return;
+            
+            instance.OnCommonUpdate();
         }
     }
 
@@ -180,7 +180,7 @@ public class Patches
                 {
                     if (SM64Context.Instance != null)
                     {
-                        __instance.RunSynchronously(() => { SM64Context.Instance?.Dispose(); });
+                        __instance.RunSynchronously(() => SM64Context.Instance.Dispose());
                     }
 
                     return false;

--- a/ResoniteMario64/ResoniteMario64.csproj
+++ b/ResoniteMario64/ResoniteMario64.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Version>1.0.0</Version>
     <Authors>art0007i, NepuShiro</Authors>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RepositoryUrl>https://github.com/art0007i/ResoniteMario64</RepositoryUrl>
     <PackageId>art0007i.ResoniteMario64</PackageId>
     <Product>ResoniteMario64</Product>
@@ -27,12 +27,12 @@
   <!-- Modding dependencies -->
   <ItemGroup>
     <PackageReference Include="BepInEx.ResonitePluginInfoProps" Version="3.*" />
-    <PackageReference Include="ResoniteModding.BepInExResoniteShim" Version="0.8.*" />
+    <PackageReference Include="ResoniteModding.BepInExResoniteShim" Version="0.9.*" />
   </ItemGroup>
 
   <!-- NuGet fallback stripped game references -->
   <ItemGroup Condition="!Exists('$(GamePath)')">
-    <PackageReference Include="Resonite.GameLibs" Version="2025.*" />
+    <PackageReference Include="Resonite.GameLibs" Version="2025.*" PrivateAssets="all"/>
   </ItemGroup>
 
   <!-- Local game references -->


### PR DESCRIPTION
This adds SyncedVariables for Mario's Coin Count, Red Coin Collection count (also changes the sound if it's not already overriden), and Star count.
It also fixes the InteractionHandler patch constantly running and eating performance (possibly, needs testing)
I also made the CreateOverrideOnWrite on the VUO to be true, if we ever make a way to change the audio for non-modded users